### PR TITLE
Add DNS troubleshooting section for Tailscale internet connectivity issues

### DIFF
--- a/docs/Networking/Tailscale/Introduction.mdx
+++ b/docs/Networking/Tailscale/Introduction.mdx
@@ -162,7 +162,7 @@ ping phone
 ```bash
 # Enable MagicDNS in the Tailscale admin console first
 # Then accept DNS settings on the client
-tailscale set --accept-dns
+tailscale set --accept-dns=true
 
 # Check DNS configuration
 tailscale status --json | jq '.MagicDNSSuffix'
@@ -191,7 +191,7 @@ cat /etc/resolv.conf
 ```bash
 # Configure custom DNS servers in the Tailscale admin console
 # Then accept DNS settings on clients
-tailscale set --accept-dns
+tailscale set --accept-dns=true
 
 # Disable Magic DNS (client won't use Tailscale DNS settings)
 tailscale set --accept-dns=false
@@ -326,6 +326,8 @@ When Tailscale is running, you might experience issues accessing the internet en
 - If Tailscale's DNS configuration is incomplete or conflicts with your network setup, all domain name resolution fails
 - IP addresses still work because they don't require DNS resolution
 - This affects all internet access, not just your own services
+
+**Note**: If you can't ping IP addresses either, the issue may be routing-related (e.g., misconfigured exit node). Check `tailscale status` to see if you're using an exit node and disable it with `tailscale set --exit-node=` if needed.
 
 **Symptoms**:
 ```bash
@@ -533,7 +535,7 @@ sudo tailscale up
 # - Set custom nameservers for your domain
 # - Enable MagicDNS for .ts.net domains
 # Then accept DNS settings on clients
-tailscale set --accept-dns
+tailscale set --accept-dns=true
 
 # This allows:
 # - Public domains → Public DNS (configured in admin console)

--- a/docs/Networking/Tailscale/Introduction.mdx
+++ b/docs/Networking/Tailscale/Introduction.mdx
@@ -394,7 +394,8 @@ tailscale set --accept-dns=true
 # For systemd-resolved systems (Ubuntu/Debian):
 # Option 3a: Temporary runtime configuration (recommended for testing)
 # First identify your uplink interface:
-ip route get 1.1.1.1 | grep -oP 'dev \K\w+'
+ip route get 1.1.1.1
+# Look for "dev" in the output and use that interface name (e.g., eth0, wlan0)
 # Then set DNS on that interface (replace eth0 with your actual interface):
 sudo resolvectl dns eth0 1.1.1.1 8.8.8.8
 # Note: This is temporary and will be lost on reboot

--- a/docs/Networking/Tailscale/Introduction.mdx
+++ b/docs/Networking/Tailscale/Introduction.mdx
@@ -429,7 +429,7 @@ tailscale set --accept-dns=false
 tailscale set --accept-dns=true
 ```
 
-#### **2. Routing Table Changes**
+#### **3. Routing Table Changes**
 
 **Problem**: Tailscale modifies routing tables
 ```bash
@@ -446,7 +446,7 @@ ip route show
 sudo ip route add 203.0.113.0/24 via 192.168.1.1 dev eth0
 ```
 
-#### **3. Interface Priority**
+#### **4. Interface Priority**
 
 **Problem**: Tailscale interface takes precedence
 ```bash
@@ -462,7 +462,7 @@ sudo ip route add 203.0.113.0/24 via 192.168.1.1 dev eth0
 sudo ip route change default via 192.168.1.1 dev eth0 metric 100
 ```
 
-#### **4. Firewall Rule Conflicts**
+#### **5. Firewall Rule Conflicts**
 
 **Problem**: Tailscale firewall rules block local access
 ```bash

--- a/docs/Networking/Tailscale/Introduction.mdx
+++ b/docs/Networking/Tailscale/Introduction.mdx
@@ -359,7 +359,7 @@ tailscale status
 **Option 1: Disable Tailscale DNS (Quickest Fix)**
 ```bash
 # Disable Tailscale DNS management
-tailscale up --accept-dns=false
+tailscale set --accept-dns=false
 
 # This restores your original DNS settings
 # You'll lose Magic DNS for .ts.net domains but internet will work normally
@@ -372,7 +372,7 @@ tailscale up --accept-dns=false
 # 3. Add reliable DNS servers (e.g., 1.1.1.1, 8.8.8.8)
 # 4. Enable "Override local DNS"
 # 5. Then on your device:
-tailscale up --accept-dns=true
+tailscale set --accept-dns=true
 ```
 
 **Option 3: Manual DNS Configuration (Advanced)**
@@ -380,23 +380,20 @@ tailscale up --accept-dns=true
 # WARNING: Manual DNS changes may be temporary and overwritten
 
 # For systemd-resolved systems (Ubuntu/Debian):
-# Create or edit resolved configuration
-sudo nano /etc/systemd/resolved.conf
-
-# Add these lines:
+# Edit resolved configuration file
+sudo tee /etc/systemd/resolved.conf > /dev/null << EOF
 [Resolve]
 DNS=1.1.1.1 8.8.8.8
 FallbackDNS=9.9.9.9
+EOF
 
 # Restart systemd-resolved
 sudo systemctl restart systemd-resolved
 
 # For other systems, edit /etc/resolv.conf (temporary fix):
 # Note: This file is often managed by the system and changes may be lost
-sudo nano /etc/resolv.conf
-# Add:
-nameserver 1.1.1.1
-nameserver 8.8.8.8
+echo "nameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf
 ```
 
 **Option 4: Reset Network Configuration**

--- a/docs/Networking/Tailscale/Introduction.mdx
+++ b/docs/Networking/Tailscale/Introduction.mdx
@@ -329,13 +329,13 @@ When Tailscale is running, you might experience issues accessing your services v
 **Symptoms**:
 ```bash
 # These work (IP addresses)
-ping 1.1.1.1          # ✅ Works
-ping 8.8.8.8          # ✅ Works
-curl http://1.1.1.1   # ✅ Works
+ping 1.1.1.1          # Works
+ping 8.8.8.8          # Works
+curl http://1.1.1.1   # Works
 
 # These fail (domain names)
-ping google.com       # ❌ Fails - "Name or service not known"
-curl https://google.com # ❌ Fails - DNS resolution error
+ping google.com       # Fails - "Name or service not known"
+curl https://google.com # Fails - DNS resolution error
 ```
 
 **Diagnosis**:
@@ -347,8 +347,11 @@ cat /etc/resolv.conf
 nslookup google.com
 dig google.com
 
-# Check Tailscale DNS status
-tailscale status | grep -i dns
+# Check DNS status (Linux with systemd)
+resolvectl status
+
+# Check Tailscale status
+tailscale status
 ```
 
 **Solutions**:
@@ -356,7 +359,7 @@ tailscale status | grep -i dns
 **Option 1: Disable Tailscale DNS (Quickest Fix)**
 ```bash
 # Disable Tailscale DNS management
-tailscale set --accept-dns=false
+tailscale up --accept-dns=false
 
 # This restores your original DNS settings
 # You'll lose Magic DNS for .ts.net domains but internet will work normally
@@ -369,25 +372,31 @@ tailscale set --accept-dns=false
 # 3. Add reliable DNS servers (e.g., 1.1.1.1, 8.8.8.8)
 # 4. Enable "Override local DNS"
 # 5. Then on your device:
-tailscale set --accept-dns=true
+tailscale up --accept-dns=true
 ```
 
-**Option 3: Manual DNS Configuration**
+**Option 3: Manual DNS Configuration (Advanced)**
 ```bash
-# Temporarily fix by manually setting DNS servers
-# Edit /etc/resolv.conf (changes may be overwritten)
-sudo nano /etc/resolv.conf
+# WARNING: Manual DNS changes may be temporary and overwritten
+
+# For systemd-resolved systems (Ubuntu/Debian):
+# Create or edit resolved configuration
+sudo nano /etc/systemd/resolved.conf
 
 # Add these lines:
+[Resolve]
+DNS=1.1.1.1 8.8.8.8
+FallbackDNS=9.9.9.9
+
+# Restart systemd-resolved
+sudo systemctl restart systemd-resolved
+
+# For other systems, edit /etc/resolv.conf (temporary fix):
+# Note: This file is often managed by the system and changes may be lost
+sudo nano /etc/resolv.conf
+# Add:
 nameserver 1.1.1.1
 nameserver 8.8.8.8
-
-# Or use systemd-resolved (Ubuntu/Debian)
-sudo systemctl edit systemd-resolved
-# Add:
-[Service]
-ExecStart=
-ExecStart=/lib/systemd/systemd-resolved --dns=1.1.1.1 --dns=8.8.8.8
 ```
 
 **Option 4: Reset Network Configuration**

--- a/docs/Networking/Tailscale/Introduction.mdx
+++ b/docs/Networking/Tailscale/Introduction.mdx
@@ -316,7 +316,92 @@ When Tailscale is running, you might experience issues accessing your services v
 
 ### **Common Issues and Causes**
 
-#### **1. DNS Resolution Conflicts**
+#### **1. Internet Access Lost But Can Still Ping IP Addresses**
+
+**Problem**: After running `sudo tailscale up`, you can no longer browse websites or access services by domain name, but you can still ping IP addresses like `1.1.1.1` or `8.8.8.8`.
+
+**Why This Happens**:
+- Tailscale modifies your system's DNS configuration when Magic DNS is enabled
+- Your system may start using Tailscale's DNS servers instead of your original DNS servers
+- If Tailscale's DNS configuration is incomplete or conflicts with your network setup, domain name resolution fails
+- IP addresses still work because they don't require DNS resolution
+
+**Symptoms**:
+```bash
+# These work (IP addresses)
+ping 1.1.1.1          # ✅ Works
+ping 8.8.8.8          # ✅ Works
+curl http://1.1.1.1   # ✅ Works
+
+# These fail (domain names)
+ping google.com       # ❌ Fails - "Name or service not known"
+curl https://google.com # ❌ Fails - DNS resolution error
+```
+
+**Diagnosis**:
+```bash
+# Check current DNS configuration
+cat /etc/resolv.conf
+
+# Test DNS resolution
+nslookup google.com
+dig google.com
+
+# Check Tailscale DNS status
+tailscale status | grep -i dns
+```
+
+**Solutions**:
+
+**Option 1: Disable Tailscale DNS (Quickest Fix)**
+```bash
+# Disable Tailscale DNS management
+tailscale set --accept-dns=false
+
+# This restores your original DNS settings
+# You'll lose Magic DNS for .ts.net domains but internet will work normally
+```
+
+**Option 2: Configure Proper DNS Servers in Tailscale Admin Console**
+```bash
+# 1. Go to Tailscale admin console (https://login.tailscale.com/admin)
+# 2. Navigate to DNS settings
+# 3. Add reliable DNS servers (e.g., 1.1.1.1, 8.8.8.8)
+# 4. Enable "Override local DNS"
+# 5. Then on your device:
+tailscale set --accept-dns=true
+```
+
+**Option 3: Manual DNS Configuration**
+```bash
+# Temporarily fix by manually setting DNS servers
+# Edit /etc/resolv.conf (changes may be overwritten)
+sudo nano /etc/resolv.conf
+
+# Add these lines:
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+
+# Or use systemd-resolved (Ubuntu/Debian)
+sudo systemctl edit systemd-resolved
+# Add:
+[Service]
+ExecStart=
+ExecStart=/lib/systemd/systemd-resolved --dns=1.1.1.1 --dns=8.8.8.8
+```
+
+**Option 4: Reset Network Configuration**
+```bash
+# If other options don't work, restart networking
+sudo systemctl restart systemd-resolved  # Ubuntu/Debian
+sudo systemctl restart NetworkManager    # Most Linux distros
+
+# Or restart Tailscale
+sudo tailscale down
+sudo tailscale up
+```
+
+#### **2. DNS Resolution Conflicts**
 
 **Problem**: Magic DNS may override local DNS resolution if configured
 ```bash

--- a/docs/Networking/Tailscale/Introduction.mdx
+++ b/docs/Networking/Tailscale/Introduction.mdx
@@ -331,7 +331,6 @@ When Tailscale is running, you might experience issues accessing your services v
 # These work (IP addresses)
 ping 1.1.1.1          # Works
 ping 8.8.8.8          # Works
-curl http://1.1.1.1   # Works
 
 # These fail (domain names)
 ping google.com       # Fails - "Name or service not known"
@@ -380,18 +379,22 @@ tailscale set --accept-dns=true
 # WARNING: Manual DNS changes may be temporary and overwritten
 
 # For systemd-resolved systems (Ubuntu/Debian):
-# Edit resolved configuration file
-sudo tee /etc/systemd/resolved.conf > /dev/null << EOF
-[Resolve]
-DNS=1.1.1.1 8.8.8.8
-FallbackDNS=9.9.9.9
-EOF
+# Option 3a: Temporary runtime configuration (recommended for testing)
+sudo resolvectl dns tailscale0 1.1.1.1 8.8.8.8
+# Note: This is temporary and will be lost on reboot
 
-# Restart systemd-resolved
+# Option 3b: Persistent configuration (backup existing settings first)
+sudo cp /etc/systemd/resolved.conf /etc/systemd/resolved.conf.bak
+# Edit the file to uncomment and set DNS lines:
+# DNS=1.1.1.1 8.8.8.8
+# FallbackDNS=9.9.9.9
+# Then restart:
 sudo systemctl restart systemd-resolved
 
-# For other systems, edit /etc/resolv.conf (temporary fix):
-# Note: This file is often managed by the system and changes may be lost
+# For other systems, check if /etc/resolv.conf is managed:
+ls -l /etc/resolv.conf
+# If it's a symlink to systemd-resolved, use resolvectl instead
+# If it's a regular file, you can edit it (changes may be temporary):
 echo "nameserver 1.1.1.1" | sudo tee /etc/resolv.conf
 echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf
 ```

--- a/docs/Networking/Tailscale/Introduction.mdx
+++ b/docs/Networking/Tailscale/Introduction.mdx
@@ -318,6 +318,16 @@ When Tailscale is running, you might experience issues accessing the internet en
 
 #### **1. Complete Internet Access Lost But Can Still Ping IP Addresses**
 
+**🚨 Quick Fix (Try This First)**:
+```bash
+# If your internet completely stopped working after tailscale up:
+tailscale set --accept-dns=false
+
+# If you can't even ping IP addresses, check for exit node issues:
+tailscale status  # Look for "Exit node:" line
+tailscale set --exit-node=  # Disable exit node if active
+```
+
 **Problem**: After running `sudo tailscale up`, you completely lose internet access - can't browse websites, access google.com, or use any internet services by domain name, but you can still ping IP addresses like `1.1.1.1` or `8.8.8.8`.
 
 **Why This Happens**:
@@ -400,9 +410,13 @@ sudo systemctl restart systemd-resolved
 # For other systems, check if /etc/resolv.conf is managed:
 ls -l /etc/resolv.conf
 # If it's a symlink to systemd-resolved, use resolvectl instead
-# If it's a regular file, you can edit it (changes may be temporary):
-echo "nameserver 1.1.1.1" | sudo tee /etc/resolv.conf
-echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf
+# ONLY do the following if /etc/resolv.conf is NOT a symlink:
+if [ ! -L /etc/resolv.conf ]; then
+    echo "nameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf
+else
+    echo "WARNING: /etc/resolv.conf is a symlink - use resolvectl instead"
+fi
 ```
 
 **Option 4: Reset Network Configuration**

--- a/docs/Networking/Tailscale/Introduction.mdx
+++ b/docs/Networking/Tailscale/Introduction.mdx
@@ -310,21 +310,22 @@ Sensitive services only accessible via Tailscale:
 # Not exposed through reverse proxy
 ```
 
-## **Why Public IP Access May Stop Working with Tailscale**
+## **Why Internet Access May Stop Working with Tailscale**
 
-When Tailscale is running, you might experience issues accessing your services via public IP and domain names. This happens due to **routing conflicts** and **DNS resolution changes**.
+When Tailscale is running, you might experience issues accessing the internet entirely - unable to browse websites, access services, or resolve domain names. This happens due to **routing conflicts** and **DNS resolution changes** that can completely break internet connectivity.
 
 ### **Common Issues and Causes**
 
-#### **1. Internet Access Lost But Can Still Ping IP Addresses**
+#### **1. Complete Internet Access Lost But Can Still Ping IP Addresses**
 
-**Problem**: After running `sudo tailscale up`, you can no longer browse websites or access services by domain name, but you can still ping IP addresses like `1.1.1.1` or `8.8.8.8`.
+**Problem**: After running `sudo tailscale up`, you completely lose internet access - can't browse websites, access google.com, or use any internet services by domain name, but you can still ping IP addresses like `1.1.1.1` or `8.8.8.8`.
 
 **Why This Happens**:
 - Tailscale modifies your system's DNS configuration when Magic DNS is enabled
 - Your system may start using Tailscale's DNS servers instead of your original DNS servers
-- If Tailscale's DNS configuration is incomplete or conflicts with your network setup, domain name resolution fails
+- If Tailscale's DNS configuration is incomplete or conflicts with your network setup, all domain name resolution fails
 - IP addresses still work because they don't require DNS resolution
+- This affects all internet access, not just your own services
 
 **Symptoms**:
 ```bash
@@ -360,7 +361,7 @@ tailscale status
 # Disable Tailscale DNS management
 tailscale set --accept-dns=false
 
-# This restores your original DNS settings
+# This stops Tailscale from managing DNS and reverts to your system's DNS configuration
 # You'll lose Magic DNS for .ts.net domains but internet will work normally
 ```
 
@@ -380,7 +381,10 @@ tailscale set --accept-dns=true
 
 # For systemd-resolved systems (Ubuntu/Debian):
 # Option 3a: Temporary runtime configuration (recommended for testing)
-sudo resolvectl dns tailscale0 1.1.1.1 8.8.8.8
+# First identify your uplink interface:
+ip route get 1.1.1.1 | grep -oP 'dev \K\w+'
+# Then set DNS on that interface (replace eth0 with your actual interface):
+sudo resolvectl dns eth0 1.1.1.1 8.8.8.8
 # Note: This is temporary and will be lost on reboot
 
 # Option 3b: Persistent configuration (backup existing settings first)

--- a/package-lock.json
+++ b/package-lock.json
@@ -18519,12 +18519,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "peer": true
-    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -19985,7 +19979,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18519,6 +18519,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "peer": true
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -19979,7 +19985,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
This PR adds comprehensive documentation for a common Tailscale issue where users lose internet access after running `sudo tailscale up` but can still ping IP addresses like `1.1.1.1`.

## What's Added

**New troubleshooting section**: "Internet Access Lost But Can Still Ping IP Addresses"
- Explains why this happens (DNS configuration conflicts)
- Provides clear symptoms and diagnostic commands
- Offers 4 solution approaches from quick fixes to advanced configuration

## Key Features

- **Symptom-based troubleshooting**: Addresses the specific scenario users encounter
- **Multiple solution paths**: From disabling Tailscale DNS to proper configuration
- **Safety improvements**: Uses safer systemd-resolved configuration methods
- **Consistency**: Harmonizes CLI command syntax throughout the document
- **Editor-agnostic**: Replaces editor-specific commands with portable alternatives

## Technical Improvements

- Uses consistent `tailscale set --accept-dns` syntax
- Replaces `nano` commands with `tee` and `echo` for better portability
- Fixes section numbering sequence in troubleshooting guide
- Reverts unrelated package-lock.json changes

This documentation helps users quickly resolve DNS resolution issues that commonly occur after Tailscale setup, providing both quick fixes and comprehensive solutions.

---

🤖 This PR was created with Mentat. See my steps and cost [here](https://mentat.ai/gh/TrueBankai416/BankaiTechDocs/agent/66534107-addd-4c1c-954f-fec193ee6fac) ✨

- [x] Wake on any new activity.