### PR TITLE
fix(nextcloud-talk): harden Janus and coturn config based on real-world review

### DIFF
--- a/docs/Nextcloud/Docs/Talk.mdx
+++ b/docs/Nextcloud/Docs/Talk.mdx
@@ -102,11 +102,19 @@ no-multicast-peers
 no-tls
 
 # Block relay to private/loopback/multicast ranges (prevents SSRF via TURN)
-denied-peer-ip=127.0.0.0-127.255.255.255
+denied-peer-ip=0.0.0.0-0.255.255.255
 denied-peer-ip=10.0.0.0-10.255.255.255
-denied-peer-ip=192.168.0.0-192.168.255.255
-denied-peer-ip=172.16.0.0-172.31.255.255
+denied-peer-ip=100.64.0.0-100.127.255.255
+denied-peer-ip=127.0.0.0-127.255.255.255
 denied-peer-ip=169.254.0.0-169.254.255.255
+denied-peer-ip=172.16.0.0-172.31.255.255
+denied-peer-ip=192.0.0.0-192.0.0.255
+denied-peer-ip=192.0.2.0-192.0.2.255
+denied-peer-ip=192.168.0.0-192.168.255.255
+denied-peer-ip=198.18.0.0-198.19.255.255
+denied-peer-ip=198.51.100.0-198.51.100.255
+denied-peer-ip=203.0.113.0-203.0.113.255
+denied-peer-ip=240.0.0.0-255.255.255.255
 ```
 
 :::tip[Logging]
@@ -188,6 +196,9 @@ nat: {
     # 1:1 NAT mapping — public WAN IP so Janus advertises the correct ICE candidates
     # Get your WAN IP with: curl -s -4 https://ifconfig.me
     nat_1_1_mapping = "<WAN_IP>"
+    # keep private IP in candidates too so LAN clients can connect directly
+    keep_private_host = true
+    full_trickle = true
     ice_ignore_list = "vmnet"
 }
 
@@ -213,7 +224,9 @@ general: {
     json = "indented"
     grouping = true
     # at minimum: handles, media, webrtc
-    events = "plugins,handles,media,webrtc"
+    events = "handles,media,webrtc"
+    # prevents memory runaway if signaling goes down and reconnects
+    events_cap_on_reconnect = 1000
     # points to the signaling server WebSocket endpoint on the host
     backend = "ws://localhost:8081/spreed"
     subprotocol = "janus-events"

--- a/docs/Nextcloud/Docs/Talk.mdx
+++ b/docs/Nextcloud/Docs/Talk.mdx
@@ -80,6 +80,7 @@ nano /opt/docker/nextcloud/coturn/turnserver.conf
 
 ```ini title="/opt/docker/nextcloud/coturn/turnserver.conf — highlighted items will need to be modified" showLineNumbers
 listening-port=3478
+no-cli
 fingerprint
 use-auth-secret
 // highlight-next-line
@@ -116,6 +117,14 @@ denied-peer-ip=198.51.100.0-198.51.100.255
 denied-peer-ip=203.0.113.0-203.0.113.255
 denied-peer-ip=240.0.0.0-255.255.255.255
 ```
+
+:::tip[`allowed-peer-ip`]
+If you run a VPN or have Docker bridge networks (e.g. `172.17.0.0/16`) that need to reach each other via TURN, add `allowed-peer-ip` entries to punch holes in the denied ranges:
+```ini
+allowed-peer-ip=172.17.0.1
+allowed-peer-ip=10.200.0.0-10.200.0.8
+```
+:::
 
 :::tip[Logging]
 Add `verbose` on its own line to enable detailed coturn logs during initial testing. Remove it once everything is working.
@@ -205,6 +214,8 @@ nat: {
 media: {
     # Constrain Janus media ports so they can be port-forwarded on the router
     rtp_port_range = "10000-20000"
+    ipv6 = false
+    ipv6_linklocal = false
 }
 
 events: {
@@ -221,7 +232,7 @@ nano /opt/docker/nextcloud/janus/janus.eventhandler.wsevh.jcfg
 ```hcl title="/opt/docker/nextcloud/janus/janus.eventhandler.wsevh.jcfg" showLineNumbers
 general: {
     enabled = true
-    json = "indented"
+    json = "compact"
     grouping = true
     # at minimum: handles, media, webrtc
     events = "handles,media,webrtc"
@@ -230,6 +241,21 @@ general: {
     # points to the signaling server WebSocket endpoint on the host
     backend = "ws://localhost:8081/spreed"
     subprotocol = "janus-events"
+}
+```
+
+```bash
+nano /opt/docker/nextcloud/janus/janus.transport.websockets.jcfg
+```
+
+```hcl title="/opt/docker/nextcloud/janus/janus.transport.websockets.jcfg"
+general: {
+    json = "compact"
+    ws = true
+    ws_port = 8188
+    # bind to loopback only — only the signaling server needs this port
+    ws_interface = "lo"
+    wss = false
 }
 ```
 
@@ -358,6 +384,7 @@ services:
     volumes:
       - ./janus/janus.jcfg:/usr/local/etc/janus/janus.jcfg:ro
       - ./janus/janus.eventhandler.wsevh.jcfg:/usr/local/etc/janus/janus.eventhandler.wsevh.jcfg:ro
+      - ./janus/janus.transport.websockets.jcfg:/usr/local/etc/janus/janus.transport.websockets.jcfg:ro
     network_mode: host
 
   signaling:

--- a/docs/Nextcloud/Docs/Talk.mdx
+++ b/docs/Nextcloud/Docs/Talk.mdx
@@ -542,6 +542,20 @@ You should see allocation and permission lines as clients connect through the re
 
 ---
 
+## **Federated Calls**
+
+Nextcloud Talk supports calling users on other Nextcloud instances. The **host server** (the one that owns the conversation room) provides the signaling and Janus infrastructure — federated participants connect to the host's HPB, not their own.
+
+| Component | Host server | Participant's server |
+|---|---|---|
+| Signaling server | ✅ Required | ❌ Not needed — joins host's |
+| Janus (MCU) | ✅ Required | ❌ Not needed — connects to host's |
+| TURN/STUN | ✅ Required | ✅ Recommended for their own NAT traversal |
+
+The federated participant's Nextcloud instance only needs the **Talk** app installed. They will use their own TURN configuration (if set) to get relay candidates on their side, then connect through to the host's Janus using those candidates.
+
+---
+
 ## **Troubleshooting**
 
 | Symptom | Likely Cause |

--- a/docs/Nextcloud/Docs/Talk.mdx
+++ b/docs/Nextcloud/Docs/Talk.mdx
@@ -111,10 +111,12 @@ denied-peer-ip=169.254.0.0-169.254.255.255
 denied-peer-ip=172.16.0.0-172.31.255.255
 denied-peer-ip=192.0.0.0-192.0.0.255
 denied-peer-ip=192.0.2.0-192.0.2.255
+denied-peer-ip=192.88.99.0-192.88.99.255
 denied-peer-ip=192.168.0.0-192.168.255.255
 denied-peer-ip=198.18.0.0-198.19.255.255
 denied-peer-ip=198.51.100.0-198.51.100.255
 denied-peer-ip=203.0.113.0-203.0.113.255
+denied-peer-ip=224.0.0.0-239.255.255.255
 denied-peer-ip=240.0.0.0-255.255.255.255
 ```
 
@@ -184,7 +186,7 @@ WORKDIR /usr/src/janus/janus-gateway-$JANUS_VERSION
 CMD [ "janus", "--full-trickle" ]
 ```
 
-The signaling server requires Janus to broadcast events over WebSocket. Create the two required config overrides:
+The signaling server requires Janus to broadcast events over WebSocket. Create the three required config overrides:
 
 ```bash
 nano /opt/docker/nextcloud/janus/janus.jcfg


### PR DESCRIPTION
## Summary

Improvements to the Nextcloud Talk HPB documentation based on review of a working real-world bare-metal configuration.

## Changes

### coturn (`turnserver.conf`)
- Add `no-cli` to disable the management CLI interface
- Expand `denied-peer-ip` to cover all RFC-6890 reserved ranges (13 ranges, up from 5)
- Add `allowed-peer-ip` tip for users with VPNs or Docker bridge networks

### Janus (`janus.jcfg`)
- Add `keep_private_host = true` — keeps both public and private IPs as ICE candidates (helps LAN clients connect directly)
- Add `full_trickle = true` — more efficient ICE negotiation
- Add `ipv6 = false` + `ipv6_linklocal = false` in `media` section

### Janus event handler (`janus.eventhandler.wsevh.jcfg`)
- Change `json` to `compact` (reduces event payload size)
- Add `events_cap_on_reconnect = 1000` (prevents memory runaway if signaling disconnects)
- Trim events to `handles,media,webrtc` (remove unused `plugins`)

### New: `janus.transport.websockets.jcfg`
- Binds Janus WebSocket (port 8188) to loopback only (`ws_interface = "lo"`)
- Prevents external access to the Janus API — only the signaling server needs this port
- Mounted in docker-compose alongside the other Janus configs