### PR TITLE
fix: prevent left sidebar items from being hidden behind bottom bar

### DIFF
--- a/src/components/BottomBar/styles.module.css
+++ b/src/components/BottomBar/styles.module.css
@@ -133,11 +133,11 @@
 }
 
 :global(body) {
-  padding-bottom: 60px;
+  padding-bottom: var(--bottom-bar-height);
 }
 
 @media (max-width: 768px) {
   :global(body) {
-    padding-bottom: 50px;
+    padding-bottom: calc(var(--bottom-bar-height) - 10px);
   }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -24,6 +24,7 @@
   --ifm-toc-border-color: rgba(39, 74, 122, 0.3);
   --ifm-card-background-color: rgba(255, 255, 255, 0.9);
   --floating-widget-clearance: 225px; /* Greater the number = more clearance reserved for widgets (shorter TOC) */
+  --bottom-bar-height: 60px; /* Update this if the BottomBar height changes */
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -108,7 +109,7 @@ code {
 /* Prevent left sidebar items from being hidden behind the bottom bar */
 @media (min-width: 997px) {
   .theme-doc-sidebar-menu {
-    padding-bottom: 80px !important;
+    padding-bottom: calc(var(--bottom-bar-height) + 20px) !important;
   }
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -105,6 +105,13 @@ code {
   border: 1px solid color-mix(in srgb, var(--ifm-color-primary) 40%, transparent);
 }
 
+/* Prevent left sidebar items from being hidden behind the bottom bar */
+@media (min-width: 997px) {
+  .theme-doc-sidebar-menu {
+    padding-bottom: 80px !important;
+  }
+}
+
 /* Prevent TOC from overlapping with floating widgets at bottom right */
 .table-of-contents {
   max-height: calc(100vh - var(--floating-widget-clearance)) !important;


### PR DESCRIPTION
## Problem

The left sidebar navigation was being partially covered by the fixed bottom bar, making items like **Ubuntu** inaccessible without knowing to scroll further.

This is the same issue that was previously fixed for the right-side TOC.

## Fix

Added `padding-bottom` to `.theme-doc-sidebar-menu` so the last sidebar item always scrolls into view above the bottom bar — identical in approach to the existing TOC fix.